### PR TITLE
Suggestion: add `goldilocks` to the Adaptive Designs section

### DIFF
--- a/ClinicalTrials.md
+++ b/ClinicalTrials.md
@@ -79,6 +79,8 @@ Contributions are always welcome and encouraged. You can contribute by emailing 
 
 - `r pkg("gMCP")` provides functions and a graphical user interface for graphical described multiple test procedures. Examples of weighted tests that are available in gMCP are the weighted Bonferroni, parametric and Simes tests.
 
+- `r pkg("goldilocks")` simulates and evaluates Goldilocks adaptive clinical trial designs for one- and two-arm trials with time-to-event or fixed-time binary endpoints. It uses predictive probabilities to determine during accrual whether the current sample size is sufficient or further enrollment would be futile, and supports frequentist and Bayesian final analyses. See Broglio et al. (2014) `r doi("10.1080/10543406.2014.888569")`.
+
 - `r pkg("graphicalMCP")` is a low-dependency implementation of graphical MCPs which allow mixed types of tests. It also includes power simulations and visualization of graphical MCPs.
 
 - `r pkg("gsMAMS")` It provides functions to generate operating characteristics and to calculate Sequential Conditional Probability Ratio Tests(SCPRT) efficacy and futility boundary values along with sample/event size of Multi-Arm Multi-Stage(MAMS) trials for different outcomes. The package is based on Wu et al. (2023) `r doi("10.1002/sim.9682")`, Wu and Li (2023) `r doi(" 10.1002/sim.9682")`, and Wu et al. (2023) *Group Sequential Multi-Arm Multi-Stage Trial Design with Ordinal Endpoints* (In preparation). 


### PR DESCRIPTION
Hi,

I would like to suggest adding [`goldilocks`](https://cran.r-project.org/package=goldilocks) to the **Design → Adaptive Designs** section of the ClinicalTrials task view.

`goldilocks` is a CRAN package for simulating and evaluating Goldilocks adaptive clinical trial designs for one- and two-arm trials with time-to-event or fixed-time binary endpoints. It uses predictive probabilities during accrual to determine whether the current sample size is sufficient or further enrollment would be futile. The package supports frequentist and Bayesian final analyses and simulation of design operating characteristics.

I think it fits naturally within Adaptive Designs because its central purpose is adaptive sample-size selection based on accumulating trial data.

The methodology is described in Broglio et al. (2014), [doi:10.1080/10543406.2014.888569](https://doi.org/10.1080/10543406.2014.888569).

Disclosure: I am the maintainer and an author of `goldilocks`.

Best wishes,  
Graeme
